### PR TITLE
feat: Make templates directory configurable

### DIFF
--- a/Framework_test.go
+++ b/Framework_test.go
@@ -1,0 +1,79 @@
+package framework_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bencbradshaw/framework"
+	"github.com/evanw/esbuild/pkg/api"
+)
+
+func TestConfigurableTemplatesDir(t *testing.T) {
+	customTemplatesPath := "custom_test_templates"
+	// Clean up any previous test runs
+	_ = os.RemoveAll(customTemplatesPath)
+
+	err := os.MkdirAll(customTemplatesPath, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create custom templates directory: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(customTemplatesPath)
+		if err != nil {
+			t.Logf("Failed to remove custom templates directory: %v", err)
+		}
+	}()
+
+	baseHTMLContent := `{{define "base"}} {{template "content" .}} {{end}}`
+	indexHTMLContent := `{{define "content"}}Custom Template Content{{end}}`
+	entryHTMLContent := `{{define "entry"}}{{end}}` // Required by HtmlRender
+
+	err = ioutil.WriteFile(filepath.Join(customTemplatesPath, "base.html"), []byte(baseHTMLContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write base.html: %v", err)
+	}
+	err = ioutil.WriteFile(filepath.Join(customTemplatesPath, "index.html"), []byte(indexHTMLContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write index.html: %v", err)
+	}
+	err = ioutil.WriteFile(filepath.Join(customTemplatesPath, "entry.html"), []byte(entryHTMLContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write entry.html: %v", err)
+	}
+
+	params := &framework.InitParams{
+		IsDevMode:                  false, // Avoid esbuild for this test
+		AutoRegisterTemplateRoutes: true,
+		TemplatesDir:               customTemplatesPath,
+		EsbuildOpts:                api.BuildOptions{
+			// Provide minimal esbuild options if dev mode were true, not strictly needed here
+		},
+	}
+
+	router := framework.Run(params)
+
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+		t.Logf("Response body: %s", rr.Body.String())
+	}
+
+	expectedContent := "Custom Template Content"
+	if !strings.Contains(rr.Body.String(), expectedContent) {
+		t.Errorf("handler returned unexpected body: got %s want substring %s",
+			rr.Body.String(), expectedContent)
+	}
+}

--- a/esbuild/build.go
+++ b/esbuild/build.go
@@ -42,7 +42,9 @@ func mergeOptions(defaultOptions, passedOptions api.BuildOptions) api.BuildOptio
 		defaultOptions.MinifyIdentifiers = passedOptions.MinifyIdentifiers
 	}
 	if len(passedOptions.Plugins) > 0 {
-		defaultOptions.Plugins = passedOptions.Plugins
+		// Append passed plugins to default plugins, ensuring no duplicates if manager carefully
+		// For example, HtmlPlugin is now added by the caller (Framework.go) into passedOptions.Plugins
+		defaultOptions.Plugins = append(defaultOptions.Plugins, passedOptions.Plugins...)
 	}
 	return defaultOptions
 }
@@ -56,7 +58,7 @@ func InitDevMode(options api.BuildOptions) api.BuildContext {
 		LogLevel:          api.LogLevelInfo,
 		Splitting:         true,
 		Format:            api.FormatESModule,
-		Plugins:           []api.Plugin{HtmlPlugin, RebuildPlugin},
+		Plugins:           []api.Plugin{RebuildPlugin}, // HtmlPlugin is now passed in via options
 		Sourcemap:         api.SourceMapLinked,
 		MinifyWhitespace:  false,
 		MinifyIdentifiers: false,
@@ -87,7 +89,7 @@ func Build(options api.BuildOptions) api.BuildResult {
 		LogLevel:    api.LogLevelInfo,
 		Splitting:   true,
 		Format:      api.FormatESModule,
-		Plugins:     []api.Plugin{HtmlPlugin},
+		Plugins:     []api.Plugin{}, // HtmlPlugin is now passed in via options
 		Sourcemap:   api.SourceMapLinked,
 	}
 	finalOptions := mergeOptions(defaultOptions, options)

--- a/templating/html.go
+++ b/templating/html.go
@@ -7,15 +7,27 @@ import (
 	"strings"
 )
 
-var templatesDir = "./templates"
-
-func HtmlRender(templateName string, data map[string]any) (string, error) {
-	fmt.Println("Rendering template: ", templateName)
+// HtmlRender renders an HTML template with the given data.
+// It takes the templates directory path, the name of the specific template file (e.g., "index.html"),
+// and a map of data to be passed to the template.
+// It expects a "base.html" and "entry.html" to be present in the templates directory.
+func HtmlRender(templatesDir string, templateName string, data map[string]any) (string, error) {
+	fmt.Println("Rendering template: ", templateName, "from", templatesDir)
 
 	files := []string{
 		filepath.Join(templatesDir, "base.html"),
 		filepath.Join(templatesDir, "entry.html"),
 		filepath.Join(templatesDir, templateName),
+	}
+
+	// Check if all files exist
+	for _, file := range files {
+		if _, err := filepath.Abs(file); err != nil {
+			// This check is mostly for sanity; template.ParseFiles will give a more specific error
+			// if a file doesn't exist or isn't readable. We're not returning error here
+			// to keep the original structure, but logging could be an option.
+			fmt.Printf("Warning: could not get absolute path for template file %s: %v\n", file, err)
+		}
 	}
 
 	tmpl, err := template.ParseFiles(files...)


### PR DESCRIPTION
This change allows you to specify a custom directory for HTML templates, addressing issue #2 (https://github.com/bencbradshaw/framework/issues/2).

The following modifications were made:

- Added a `TemplatesDir` field to `framework.InitParams`. If not provided, it defaults to "templates".
- Updated `framework.Run` and `framework.Build` to use this configurable directory path when initializing the esbuild HTML plugin and when registering routes for templates.
- Modified `esbuild.HtmlPlugin` to be a function `NewHtmlPlugin(templatesDir string)` that returns a plugin configured with the specified directory. This function now also creates the templates directory if it doesn't exist to prevent errors when writing `entry.html`.
- Updated `templating.HtmlRender` to accept `templatesDir` as a parameter instead of using a hardcoded path.
- Adjusted calls to these functions in `Framework.go` to pass the configured templates directory.
- Added a new test `TestConfigurableTemplatesDir` in `Framework_test.go` to verify that templates are correctly served from a custom directory.
- Fixed build issues in `esbuild/html-plugin.go` and `esbuild/build.go` that arose during the refactoring, ensuring that esbuild plugins are correctly merged and initialized.

All tests, including the new one for this feature, are passing.